### PR TITLE
Debug extract NYUD-v2 data from .mat

### DIFF
--- a/datasets/extract_official_train_test_set_from_mat.py
+++ b/datasets/extract_official_train_test_set_from_mat.py
@@ -39,7 +39,6 @@ import os
 import scipy.io
 import sys
 import cv2
-from pyxform.utils import unichr
 
 def convert_image(i, scene, depth_raw, image, depth_dense):
 
@@ -92,7 +91,7 @@ if __name__ == "__main__":
     print("reading", sys.argv[1])
 
     images = h5_file['images']
-    scenes = [u''.join(unichr(c) for c in h5_file[obj_ref]) for obj_ref in h5_file['sceneTypes'][0]]
+    scenes = [u''.join(chr(c[0]) for c in h5_file[obj_ref]) for obj_ref in h5_file['sceneTypes'][0]]
 
     print("processing images")
     for i, image in enumerate(images):


### PR DESCRIPTION
Hi, 

When following instructions [about NYUD-v2 data processing](https://github.com/tjqansthd/LapDepth-release?tab=readme-ov-file#nyu-depth-v2) I was facing the following error:
```shell
~/LapDepth-release/datasets$ python extract_official_train_test_set_from_mat.py nyu_depth_v2_labeled.mat splits.mat ./NYU_Depth_V2/official_splits/
Traceback (most recent call last):
  File "extract_official_train_test_set_from_mat.py", line 42, in <module>
    from pyxform.utils import unichr
ImportError: cannot import name 'unichr' from 'pyxform.utils'
```

I solved it in this branch by
- removing `pyxform`
- Replacing `unichr(c)` by `chr(c[0])`
